### PR TITLE
add k230_canmv_only_linux_defconfig file

### DIFF
--- a/configs/k230_canmv_only_linux_defconfig
+++ b/configs/k230_canmv_only_linux_defconfig
@@ -1,0 +1,56 @@
+#
+# Automatically generated file; DO NOT EDIT.
+# K230 SDK Configuration
+#
+
+#
+# board configuration
+#
+# CONFIG_BOARD_K230_EVB is not set
+# CONFIG_BOARD_K230_FPGA is not set
+# CONFIG_BOARD_K230D is not set
+CONFIG_BOARD_K230_CANMV=y
+CONFIG_BOARD_NAME="k230_evb"
+# CONFIG_QUICK_BOOT is not set
+# CONFIG_GEN_SECURITY_IMG is not set
+CONFIG_UBOOT_DEFCONFIG="k230_canmv"
+CONFIG_LINUX_DEFCONFIG="k230_evb_linux_enable_vector"
+CONFIG_LINUX_DTB="k230_canmv"
+# CONFIG_REMOTE_TEST_PLATFORM is not set
+CONFIG_GEN_IMG_SCRIPT="board/k230_evb_only_linux/gen_image.sh"
+CONFIG_RTT_CONSOLE_ID=3
+
+#
+# toolchain configurations
+#
+CONFIG_TOOLCHAIN_PREFIX_RTT="riscv64-unknown-linux-musl-"
+CONFIG_TOOLCHAIN_PATH_RTT="/opt/toolchain/riscv64-linux-musleabi_for_x86_64-pc-linux-gnu/bin"
+CONFIG_TOOLCHAIN_PREFIX_LINUX="riscv64-unknown-linux-gnu-"
+CONFIG_TOOLCHAIN_PATH_LINUX="/opt/toolchain/Xuantie-900-gcc-linux-5.10.4-glibc-x86_64-V2.6.0/bin"
+
+#
+# Memory configuration
+#
+CONFIG_MEM_TOTAL_SIZE=0x20000000
+CONFIG_MEM_LINUX_SYS_BASE=0x00000000
+CONFIG_MEM_LINUX_SYS_SIZE=0x20000000
+CONFIG_MEM_BOUNDARY_RESERVED_SIZE=0x00001000
+
+#
+# storage configurations
+#
+# CONFIG_SPI_NOR is not set
+# CONFIG_SPI_NAND is not set
+CONFIG_SDCAED=y
+
+#
+# wifi configurations
+#
+# CONFIG_AP6212A is not set
+# CONFIG_AP6256 is not set
+# CONFIG_SUPPORT_RTSMART is not set
+CONFIG_SUPPORT_LINUX=y
+CONFIG_LINUX_RUN_CORE_ID=1
+CONFIG_BUILD_DEBUG_VER=y
+# CONFIG_BUILD_RELEASE_VER is not set
+CONFIG_DBGLV=8


### PR DESCRIPTION

## PR描述:

add k230_canmv_only_linux_defconfig file

## 详细描述:

following `k230_canmv_defconfig` and `k230_evb_only_linux_defconfig` to create only linux configuration for k230-canmv device.

## 关联issue:

fix #40 

