### PR TITLE
fix environment judgement logic for enabling pip mirrors

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -48,7 +48,7 @@ RUN echo "False" > /tmp/.flag
 RUN wget -P /tmp/ "https://ai.b-bug.org/k230/downloads/aitest/aitest-0.0.2.dev20230625-py3-none-any.whl" || echo "True" > /tmp/.flag
 
 # config pip local source
-RUN FLAG=$(cat /tmp/.flag) && if [ "$FLAG" = "False" ]; then echo \
+RUN FLAG=$(cat /tmp/.flag) && if [ "$FLAG" = "True" ]; then echo \
     '[global]\n\
     timeout = 60\n\
     index-url = https://pypi.tuna.tsinghua.edu.cn/simple\n\


### PR DESCRIPTION
## PR描述:
fix environment judgement logic for enabling pip mirrors

## 详细描述:

The FLAG will be True if not in Canaan intranet, thus PIP mirrors should be enabled.
The original logic is to enable PIP mirrors in Canaan intranet, which maybe unnecessary.

## 关联issue:

fix #15

