### PR TITLE
opensbi: missing intialization

### DIFF
--- a/src/common/opensbi/lib/utils/reset/fdt_reset_thead.c
+++ b/src/common/opensbi/lib/utils/reset/fdt_reset_thead.c
@@ -62,7 +62,7 @@ static int thead_reset_init(void *fdt, int nodeoff,
 	void *p;
 	const fdt64_t *val;
 	const fdt32_t *val_w;
-	int len, i, cnt;
+	int len, i, cnt = 0;
 	u32 t, tmp = 0;
 
 	/* Prepare clone csrs */


### PR DESCRIPTION
GCC 13.2.0 detects that cnt may not be initialized. We must not assume that a local variable is 0 if we don't initialize it.

    lib/utils/reset/fdt_reset_thead.c:23:23: error:
    ‘cnt’ may be used uninitialized [-Werror=maybe-uninitialized]
    23 |         for (i = 0; i < cnt; i++) {
       |                     ~~^~~~~