### PR TITLE
Fix potential vulnerability in cloned code

### DIFF
--- a/src/little/linux/net/can/bcm.c
+++ b/src/little/linux/net/can/bcm.c
@@ -776,6 +776,7 @@ static int bcm_delete_rx_op(struct list_head *ops, struct bcm_msg_head *mh,
 						  bcm_rx_handler, op);
 
 			list_del(&op->list);
+			synchronize_rcu();
 			bcm_remove_op(op);
 			return 1; /* done */
 		}
@@ -1501,8 +1502,12 @@ static int bcm_release(struct socket *sock)
 					  REGMASK(op->can_id),
 					  bcm_rx_handler, op);
 
-		bcm_remove_op(op);
 	}
+	
+	synchronize_rcu();
+
+	list_for_each_entry_safe(op, next, &bo->rx_ops, list)
+		bcm_remove_op(op);
 
 #if IS_ENABLED(CONFIG_PROC_FS)
 	/* remove procfs entry */


### PR DESCRIPTION
This PR fixes a potential security vulnerability that was cloned from `torvalds/linux` but did not receive the security patch.

**Vulnerability Details:**

* **Original Fix**: https://github.com/torvalds/linux/commit/853acf7caf10b828102d92d05b5c101666a6142b

**What this PR does:** This PR applies the same security patch that was applied to the original repository to eliminate the potential vulnerability in the cloned code.

**References:**

* https://github.com/torvalds/linux/commit/853acf7caf10b828102d92d05b5c101666a6142b
* [CVE-2019-19073](https://nvd.nist.gov/vuln/detail/cve-2019-19073)

Please review and merge this PR to ensure your repository is protected against this vulnerability.